### PR TITLE
Add share count tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ TopTal Social Share is a simple WordPress plugin that adds social sharing button
 ## Features
 
 - Share links for Facebook, Twitter, LinkedIn, Pinterest and WhatsApp.
+- Tracks how many times each network is shared per post.
 - Optional floating share bar on the left side of the page.
 - Choose between icon only, text only or icon with text styles.
 - Supports small, medium and large button sizes.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -69,7 +69,13 @@
 }
 
 .toptal-social-share-wrapper div a:hover {
-	color: inherit;
+        color: inherit;
+}
+
+.toptal-social-share-wrapper .share-count {
+    margin-left: 4px;
+    font-size: 0.9em;
+    color: #fff;
 }
 
 .toptal-social-share-wrapper .small {

--- a/assets/js/share-counts.js
+++ b/assets/js/share-counts.js
@@ -1,0 +1,11 @@
+jQuery(function($){
+  $(document).on('click', '.toptal-social-share-wrapper a', function(){
+    var network = $(this).closest('div').attr('class').split(' ')[0];
+    var postId = $(this).closest('.toptal-social-share-wrapper').data('post-id');
+    if(!network || !postId) {
+      return;
+    }
+    $.post(toptalShareCount.ajax_url, {action:'toptal_update_share_count', network:network, post_id:postId});
+  });
+});
+


### PR DESCRIPTION
## Summary
- track share counts for each network
- show counts next to share buttons
- add AJAX endpoint and JS to record shares
- style share count labels
- document new share count feature

## Testing
- `php -l toptal-social-share.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a08d6db408324b9dc98b3e3e53920