### PR TITLE
Add drag-and-drop share button ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ TopTal Social Share is a simple WordPress plugin that adds social sharing button
 - Supports small, medium and large button sizes.
 - Customise button colours via the WordPress colour picker.
 - Enable or disable buttons globally or per post type.
+- Drag-and-drop ordering of the share buttons.
 - Shortcode `[toptal_ss]` for manual placement.
 
 ## Installation

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,0 +1,28 @@
+#toptal-ss-order-list {
+	max-width: 260px;
+	margin: 0;
+}
+
+#toptal-ss-order-list .toptal-ss-order-item {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 12px;
+	margin: 4px 0;
+	background: #fff;
+	border: 1px solid #ccd0d4;
+	border-radius: 3px;
+	cursor: move;
+	user-select: none;
+}
+
+#toptal-ss-order-list .toptal-ss-order-item .dashicons {
+	color: #787c82;
+}
+
+#toptal-ss-order-list .toptal-ss-order-placeholder {
+	border: 1px dashed #ccd0d4;
+	background: #f6f7f7;
+	height: 36px;
+	margin: 4px 0;
+}

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -2,6 +2,12 @@
     $(document).ready(function () {
         $('.color-field').wpColorPicker();
 
+        $('#toptal-ss-order-list').sortable({
+            cursor: 'move',
+            axis: 'y',
+            placeholder: 'toptal-ss-order-placeholder'
+        });
+
         var defaultColors = $('input[name="toptal_ss_settings[default_colors]"]');
         var colorRows = defaultColors.closest('tr').nextAll();
 

--- a/includes/class-toptal-ss-assets.php
+++ b/includes/class-toptal-ss-assets.php
@@ -76,6 +76,7 @@ final class TopTal_SS_Assets {
 			return;
 		}
 		wp_enqueue_style( 'wp-color-picker' );
-		wp_enqueue_script( 'toptal-ss-admin', TOPTAL_SS_PLUGIN_DIR_ASSETS_URL . 'js/scripts.js', array( 'jquery', 'wp-color-picker' ), TOPTAL_SS_VERSION, true );
+		wp_enqueue_style( 'toptal-ss-admin', TOPTAL_SS_PLUGIN_DIR_ASSETS_URL . 'css/admin.css', array(), TOPTAL_SS_VERSION );
+		wp_enqueue_script( 'toptal-ss-admin', TOPTAL_SS_PLUGIN_DIR_ASSETS_URL . 'js/scripts.js', array( 'jquery', 'wp-color-picker', 'jquery-ui-sortable' ), TOPTAL_SS_VERSION, true );
 	}
 }

--- a/includes/class-toptal-ss-options.php
+++ b/includes/class-toptal-ss-options.php
@@ -24,6 +24,7 @@ final class TopTal_SS_Options {
 
 		return array(
 			'networks'       => array_fill_keys( $network_keys, 0 ),
+			'order'          => $network_keys,
 			'post_types'     => array(
 				'post' => 0,
 				'page' => 0,
@@ -100,7 +101,25 @@ final class TopTal_SS_Options {
 			$settings['colors'][ $key ] = array_merge( $pair, $stored_pair );
 		}
 
+		$stored_order      = ( isset( $settings['order'] ) && is_array( $settings['order'] ) ) ? array_map( 'strval', $settings['order'] ) : array();
+		$settings['order'] = self::normalize_order( $stored_order );
+
 		return array_merge( $defaults, $settings );
+	}
+
+	/**
+	 * Keep only known network keys (in their stored order) and append any
+	 * networks missing from the stored order, so newly added networks
+	 * appear at the end instead of disappearing.
+	 *
+	 * @param string[] $order Stored order, possibly stale or invalid.
+	 * @return string[]
+	 */
+	public static function normalize_order( array $order ): array {
+		$known = TopTal_SS_Networks::keys();
+		$valid = array_values( array_intersect( $order, $known ) );
+
+		return array_values( array_unique( array_merge( $valid, $known ) ) );
 	}
 
 	/**

--- a/includes/class-toptal-ss-renderer.php
+++ b/includes/class-toptal-ss-renderer.php
@@ -164,10 +164,13 @@ final class TopTal_SS_Renderer {
 		$just_icon = ( 1 === $appearance ) ? ' just_icon' : '';
 		$html      = '<div class="toptal-social-share-wrapper' . $just_icon . '" data-post-id="' . esc_attr( (string) $post_id ) . '">';
 
-		foreach ( $networks as $key => $network ) {
-			if ( intval( $enabled[ $key ] ?? 0 ) !== 1 ) {
+		$order = TopTal_SS_Options::normalize_order( is_array( $settings['order'] ?? null ) ? $settings['order'] : array() );
+
+		foreach ( $order as $key ) {
+			if ( ! isset( $networks[ $key ] ) || intval( $enabled[ $key ] ?? 0 ) !== 1 ) {
 				continue;
 			}
+			$network = $networks[ $key ];
 
 			$share_url = TopTal_SS_Networks::share_url( $key, $permalink );
 			$count     = intval( $counts[ $key ] ?? 0 );

--- a/includes/class-toptal-ss-settings.php
+++ b/includes/class-toptal-ss-settings.php
@@ -61,6 +61,7 @@ final class TopTal_SS_Settings {
 		add_settings_section( 'toptal_ss_general_section', __( 'General Options', 'toptal-ss' ), null, self::PAGE );
 		add_settings_section( 'toptal_ss_visibility_section', __( 'Visibility', 'toptal-ss' ), null, self::PAGE );
 		add_settings_section( 'toptal_ss_locations_section', __( 'Locations', 'toptal-ss' ), null, self::PAGE );
+		add_settings_section( 'toptal_ss_order_section', __( 'Button Order', 'toptal-ss' ), null, self::PAGE );
 		add_settings_section( 'toptal_ss_size_section', __( 'Button Size', 'toptal-ss' ), null, self::PAGE );
 		add_settings_section( 'toptal_ss_appearance_section', __( 'Button Appearance', 'toptal-ss' ), null, self::PAGE );
 		add_settings_section( 'toptal_ss_color_section', __( 'Button Color', 'toptal-ss' ), null, self::PAGE );
@@ -123,6 +124,7 @@ final class TopTal_SS_Settings {
 			);
 		}
 
+		add_settings_field( 'toptal_ss_order', __( 'Order:', 'toptal-ss' ), array( $this, 'render_order_list' ), self::PAGE, 'toptal_ss_order_section' );
 		add_settings_field( 'toptal_ss_size', __( 'Size:', 'toptal-ss' ), array( $this, 'render_size_select' ), self::PAGE, 'toptal_ss_size_section' );
 		add_settings_field( 'toptal_ss_appearance', __( 'Style:', 'toptal-ss' ), array( $this, 'render_appearance_radio' ), self::PAGE, 'toptal_ss_appearance_section' );
 
@@ -170,6 +172,26 @@ final class TopTal_SS_Settings {
 			checked( 1, $value, false ),
 			esc_html__( 'Check for Yes', 'toptal-ss' )
 		);
+	}
+
+	public function render_order_list(): void {
+		$settings = TopTal_SS_Options::get();
+		$networks = TopTal_SS_Networks::all();
+
+		echo '<ul id="toptal-ss-order-list">';
+		foreach ( $settings['order'] as $key ) {
+			if ( ! isset( $networks[ $key ] ) ) {
+				continue;
+			}
+			printf(
+				'<li class="toptal-ss-order-item"><span class="dashicons dashicons-menu" aria-hidden="true"></span> %s<input type="hidden" name="%s" value="%s"></li>',
+				esc_html( $networks[ $key ]['label'] ),
+				esc_attr( TopTal_SS_Options::OPTION_KEY . '[order][]' ),
+				esc_attr( $key )
+			);
+		}
+		echo '</ul>';
+		echo '<p class="description">' . esc_html__( 'Drag to reorder the share buttons.', 'toptal-ss' ) . '</p>';
 	}
 
 	public function render_size_select(): void {
@@ -247,6 +269,9 @@ final class TopTal_SS_Settings {
 				$clean[ $section ][ $key ] = ( intval( $input[ $section ][ $key ] ?? 0 ) === 1 ) ? 1 : 0;
 			}
 		}
+
+		$order          = is_array( $input['order'] ?? null ) ? array_map( 'strval', $input['order'] ) : array();
+		$clean['order'] = TopTal_SS_Options::normalize_order( $order );
 
 		$size          = strtolower( (string) ( $input['size'] ?? '' ) );
 		$clean['size'] = in_array( $size, array( 'small', 'medium', 'large' ), true ) ? $size : 'small';

--- a/tests/smoke-test.php
+++ b/tests/smoke-test.php
@@ -202,6 +202,34 @@ assert(strpos($html, 'fa-reddit') !== false && strpos($html, 'fa-envelope') !== 
 $_POST = ['post_id' => 42, 'network' => 'reddit', 'nonce' => 'test-nonce'];
 $r = call_ajax($ajax); assert($r && $r->ok && $r->payload === 1, 'reddit share counted');
 
+// ---- 6c. Button ordering -------------------------------------------------
+assert(TopTal_SS_Options::defaults()['order'] === TopTal_SS_Networks::keys(), 'default order follows registry');
+
+// normalize_order: keeps stored order, drops unknown keys, appends missing.
+$normalized = TopTal_SS_Options::normalize_order(['whatsapp', 'bogus', 'facebook']);
+assert(array_slice($normalized, 0, 2) === ['whatsapp', 'facebook'], 'stored order preserved, unknown dropped');
+assert(count($normalized) === count(TopTal_SS_Networks::keys()), 'missing networks appended');
+
+// Renderer respects configured order.
+$stored = get_option('toptal_ss_settings');
+$stored['order'] = ['twitter', 'facebook'];
+update_option('toptal_ss_settings', $stored);
+TopTal_SS_Options::flush_cache();
+$html = $renderer->buttons_html(42);
+assert(strpos($html, 'class="twitter') < strpos($html, 'class="facebook'), 'twitter rendered before facebook');
+assert(strpos($html, 'class="reddit') !== false, 'networks missing from stored order still render (appended)');
+
+// Sanitizer normalizes a posted order.
+$clean = $settings_ui->sanitize_settings(['order' => ['email', 'nope', 'twitter']]);
+assert(array_slice($clean['order'], 0, 2) === ['email', 'twitter'], 'sanitized order keeps valid keys in order');
+assert(count($clean['order']) === count(TopTal_SS_Networks::keys()), 'sanitized order is complete');
+
+// Settings stored without an order key (pre-1.2 installs) get the default appended.
+unset($stored['order']);
+update_option('toptal_ss_settings', $stored);
+TopTal_SS_Options::flush_cache();
+assert(TopTal_SS_Options::get()['order'] === TopTal_SS_Networks::keys(), 'missing order falls back to registry order');
+
 // ---- 7. Fresh-install defaults -------------------------------------------
 $GLOBALS['__options'] = [];
 TopTal_SS_Options::flush_cache();

--- a/toptal-social-share.php
+++ b/toptal-social-share.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
  * Plugin Name: TopTal Social Share
  * Description: Add various social networking share buttons to your website, including; Facebook, Twitter, Pinterest, LinkedIn and WhatsApp(mobile).
  * Author: Botez Costin
- * Version: 1.1.0
+ * Version: 1.2.0
  * Requires PHP: 7.4
  * Author URI: https://nomad-developer.co.uk/
  * Text Domain: toptal-ss
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-define( 'TOPTAL_SS_VERSION', '1.1.0' );
+define( 'TOPTAL_SS_VERSION', '1.2.0' );
 define( 'TOPTAL_SS_PLUGIN_DIR_URL', plugin_dir_url( __FILE__ ) );
 define( 'TOPTAL_SS_PLUGIN_PATH', plugin_basename( __FILE__ ) );
 define( 'TOPTAL_SS_PLUGIN_DIR_ASSETS_URL', plugin_dir_url( __FILE__ ) . 'assets/' );


### PR DESCRIPTION
## Summary

Implements the button-ordering feature that has been commented out in the codebase since v1.0, as drag-and-drop sorting on the settings screen. Bumps the plugin version to 1.2.0.

> **Note:** this PR is stacked on #12 (`claude/wordpress-plugin-analysis-o008h5`) so it only shows the ordering work. Merge #12 first; this PR can then be retargeted to `master`.

## Changes

- **Settings schema:** a new `order` array in `toptal_ss_settings`, defaulting to the network registry order.
- **Admin UI:** a "Button Order" section with a jQuery-UI-sortable list; hidden inputs submit the arrangement with the rest of the form. Styled by a small new `assets/css/admin.css` (drag handles, drop placeholder), enqueued only on the settings page.
- **Normalization:** `TopTal_SS_Options::normalize_order()` keeps the stored arrangement, drops unknown keys, and appends any networks missing from it — so settings saved before a network existed still render every enabled button. Applied on read, on sanitize, and defensively in the renderer.
- **Renderer:** buttons render in the configured order instead of registry order.

## Testing

- Smoke tests cover: default order matches the registry, normalization (unknown keys dropped, missing networks appended), the renderer honoring a custom order, the sanitizer normalizing posted orders, and pre-1.2 stored settings without an `order` key falling back cleanly.
- `php -l`, PHPCS (`WordPress-Extra` + `PHPCompatibilityWP`), and the full smoke suite all pass locally; the same checks run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A736Zbw91CXomxWzMDCrR3

---
_Generated by [Claude Code](https://claude.ai/code/session_01A736Zbw91CXomxWzMDCrR3)_